### PR TITLE
Updates to log levels & doc updates

### DIFF
--- a/Lib/EmonLogger.php
+++ b/Lib/EmonLogger.php
@@ -40,20 +40,24 @@ class EmonLogger
     }
 
     public function info ($message){
-        if ($this->log_level >= 3) $this->write("INFO",$message);
+        if ($this->log_level <= 1) $this->write("INFO",$message);
     }
 
     public function warn ($message){
-        if ($this->log_level >= 2) $this->write("WARN",$message);
+        if ($this->log_level <= 2) $this->write("WARN",$message);
     }
-    
+
     public function error ($message){
-        if ($this->log_level >= 1) $this->write("ERROR",$message);
+        if ($this->log_level <= 3) $this->write("ERROR",$message);
     }
-    
+
+    public function critical ($message){
+        if ($this->log_level <= 4) $this->write("CRITICAL",$message);
+    }
+
     private function write($type,$message){
         if (!$this->logenabled) return;
-        
+
         $now = microtime(true);
         $micro = sprintf("%03d",($now - ($now >> 0)) * 1000);
         $now = DateTime::createFromFormat('U', (int)$now); // Only use UTC for logs

--- a/default.emonpi.settings.php
+++ b/default.emonpi.settings.php
@@ -122,8 +122,8 @@
     // Log file configuration
     $log_enabled = true;
     $log_filename = '/var/log/emoncms.log';
-    // Log Level: 0=ALL, 1=ERROR, 2=WARN, 3=INFO
-    $log_level = 1;
+    // Log Level: 1=INFO, 2=WARN, 3=ERROR, 4=CRITICAL
+    $log_level = 3;
 
     // If installed on Emonpi, allow admin menu tools
     $allow_emonpi_admin = true;

--- a/default.settings.php
+++ b/default.settings.php
@@ -121,8 +121,9 @@
 //6 #### Other settings
     // Log file configuration
     $log_enabled = true;
+    // On windows or shared hosting you will likely need to specify a different logfile directory
     $log_filename = '/var/log/emoncms.log';
-    // Log Level: 0=ALL, 1=ERROR, 2=WARN, 3=INFO
+    // Log Level: 1=INFO, 2=WARN, 3=ERROR, 4=CRITICAL
     $log_level = 2;
 
     // If installed on Emonpi, allow admin menu tools

--- a/docs/RaspberryPi/install_Wheezy.md
+++ b/docs/RaspberryPi/install_Wheezy.md
@@ -102,7 +102,8 @@ Update your settings to use your Database 'user' & 'password', which will enable
 Save and exit.  
 Set write permissions for the emoncms logfile:
 
-`touch /var/www/emoncms/emoncms.log` followed by `chmod 666 /var/www/emoncms/emoncms.log`
+`sudo touch /var/log/emoncms.log` followed by  
+`sudo chmod 666 /var/log/emoncms.log`
 
 ### In an internet browser, load emoncms:
 

--- a/docs/RaspberryPi/readme.md
+++ b/docs/RaspberryPi/readme.md
@@ -106,7 +106,8 @@ Create a symlink to reference emoncms within the web root folder:
 
 Set write permissions for the emoncms logfile:
 
-`touch /var/www/emoncms/emoncms.log` followed by `chmod 666 /var/www/emoncms/emoncms.log`
+`sudo touch /var/log/emoncms.log` followed by  
+`sudo chmod 666 /var/log/emoncms.log`
 
 ### In an internet browser, load emoncms:
 

--- a/docs/SharedLinuxHostingInstall.md
+++ b/docs/SharedLinuxHostingInstall.md
@@ -17,9 +17,15 @@ i.e. You should end up with all the files in the directory public_html/emoncms/
 
 3) Create a mysql database for your emoncms installation, note down its name, username and password.
 
-4) In your shared hosting /home/username folder create a folder called emoncmsdata to hold your emoncms feed data. (Note: NOT public_html as the data files should not be publicly accessible).
+4) In your shared hosting /home/username folder create a folder called emoncmsdata to hold your emoncms feed data.  
+(Note: NOT public_html as the data files should not be publicly accessible).  
 Then create three folders within your emoncmsdata folder called: phpfiwa, phpfina and phptimeseries
 
-5) In the emoncms app directory make a copy of default_settings.php and call it settings.php. Open settings.php and enter your mysql username, password and database. In the feed_settings section uncomment the datadir defenitions and set them to the location of each of the feed engine data folders on your system.
+5) In the emoncms app directory make a copy of default_settings.php and call it settings.php.  
+Open settings.php and enter your mysql username, password and database.  
+In the feed_settings section uncomment the datadir definitions and set them to the location of each of the feed engine data folders on your system.   
+In the 'Other settings' section, change the $log_filename location to:  
+```$log_filename = dirname(__FILE__).'/' . 'emoncms.log';```
 
-6) Thats it, emoncms should now be ready to use! 
+
+6) That's it, emoncms should now be ready to use!

--- a/docs/WindowsInstall.md
+++ b/docs/WindowsInstall.md
@@ -31,7 +31,7 @@ The easiest way to do this via a GUI is through a program called phpmyadmin. The
 
 To create a database in phpmyadmin, click on Databases at the top, then enter 'emoncms' in the text input box and click create.
 
-When, in phpmyadmin, the database has been created, a new user must also be created on host "localhost" (not "%") and have a password set.  When the user has been created, the user needs to have "all" privileges over the new database that has just been created (scroll down for Database-specific privileges). Those 4 items - the new user name, password, "localhost" and database name are the values that go into the settings.php file. 
+When, in phpmyadmin, the database has been created, a new user must also be created on host "localhost" (not "%") and have a password set.  When the user has been created, the user needs to have "all" privileges over the new database that has just been created (scroll down for Database-specific privileges). Those 4 items - the new user name, password, "localhost" and database name are the values that go into the settings.php file.
 
 **Note:** this user isn't necessarily the same as one of the users who are allowed to register in emoncms once it's running.
 
@@ -41,10 +41,10 @@ When, in phpmyadmin, the database has been created, a new user must also be crea
 
 [https://github.com/emoncms/emoncms/archive/stable.zip](https://github.com/emoncms/emoncms/archive/stable.zip)
 
-    
+
 #### 6) Place emoncms in your WAMP public html / www directory
 
-Left-click on your Wamp icon, in the list you should see a link to: www directory (or possibly public html on older installations). 
+Left-click on your Wamp icon, in the list you should see a link to: www directory (or possibly public html on older installations).
 
 Open the www directory from the wamp menu link.
 
@@ -63,10 +63,10 @@ Inside this folder create 3 other folders: phpfiwa, phpfina and phptimeseries, t
 
 #### 8) Set emoncms settings.php
 
-Copy default.settings.php and rename to settings.php. Enter your database username, password, server and database name. 
+Copy default.settings.php and rename to settings.php. Enter your database username, password, server and database name.
 
 In the feedsettings section uncomment the datadir defenitions and set them to the location of each of the feed engine data folders on your system:
-    
+
     'phpfiwa'=>array(
         'datadir'=>"C:\\Users\\Username\\emoncmsdata\\phpfiwa\\"
     ),
@@ -79,10 +79,14 @@ In the feedsettings section uncomment the datadir defenitions and set them to th
 
 On Windows '\' must be escaped with another '\' hence the '\\'
 
+In the 'Other settings' section, change the $log_filename location to:
+
+    $log_filename = dirname(__FILE__).'/' . 'emoncms.log';
+
 #### 9) Thats it! Open emoncms in your browser
 
 [http://localhost/emoncms](http://localhost/emoncms)
-    
+
 Click on register and create a new user. It should now log you in and you will see the accounts page.
 
 #### 10) Sending some data to emoncms
@@ -92,10 +96,10 @@ Click on the input tab and then *Input API Help*
 Click on the example *Assign inputs to a node group* which will send 3 input values and assign them to node 1:
 
 [http://localhost/emoncms/input/post.json?node=1&csv=100,200,300](http://localhost/emoncms/input/post.json?node=1&csv=100,200,300)
-    
+
 You should see 'ok' printed to the screen.
 
-Navigate back to the inputs page and you will see 3 inputs listed under node 1. 
+Navigate back to the inputs page and you will see 3 inputs listed under node 1.
 
 Click on the wrench icon to bring up the input processing configuration page for a particular input.
 
@@ -104,7 +108,7 @@ Create a new *Log to feed* process and enter a name for the feed you'd like to c
 If you now repeat sending data via:
 
 [http://localhost/emoncms/input/post.json?node=1&csv=100,200,300](http://localhost/emoncms/input/post.json?node=1&csv=100,200,300)
-    
+
 The data will now be being stored in a feed table.
 
 After sending say 5-10 values. Navigate to *Feeds* and click on the eye button and zoom in to the last few minutes. You should see a line being drawn. If you dont see anything yet, keep sending data over a period of a couple of minutes and vary the input values.
@@ -141,6 +145,3 @@ For a more complete python gateway see the Jerome's oem_gateway here which can a
 <p><b>IE 8, 7</b> - not recommended, widgets and dashboard editor <b>do not work</b> due to no html5 canvas fix implemented but visualisations do work as these have a fix applied.</p>
 
 </div>
-
-
-


### PR DESCRIPTION
1) Raspberry install guides - create logfile in /var/log instead on
/emoncms also 'sudo' required to create & set permissions of log.
2) Change EmonLogger.php to filter messages in correct order, plus add
CRITICAL filter. Both 'settings' templates also updated to reflect
changes.
3) Update both Windows & Shared Hosting guides to use 'installation dir'
for logfile instead of default path /var/log